### PR TITLE
Update lsignal.h

### DIFF
--- a/lsignal.h
+++ b/lsignal.h
@@ -347,8 +347,11 @@ namespace lsignal
 	connection signal<R(Args...)>::connect(T *p, const U& fn, slot *owner)
 	{
 		auto mem_fn = std::move(construct_mem_fn(fn, p, make_int_sequence<sizeof...(Args)>{}));
-
-		return create_connection(std::move(mem_fn), owner);
+		
+		if (owner == nullptr)
+			return create_connection(std::move(mem_fn), std::is_base_of<slot, T>::value ? p : nullptr);
+		else
+			return create_connection(std::move(mem_fn), owner);
 	}
 
 	template<typename R, typename... Args>


### PR DESCRIPTION
For a slot object, do not need specify the owner object &f.
class foo : public lsignal::slot
{
    ...
};
...
foo f;

// disconnect when f was destroyed
s.connect([](){ ... });